### PR TITLE
Add Linux support and support for abnormal zoom domains

### DIFF
--- a/auto-zoom.py
+++ b/auto-zoom.py
@@ -21,6 +21,13 @@ def convert_time(string_date, string_time):
 	# mm/dd/y hour:minute
 	if string_date == 'today':
 		datetime_str = f'{datetime.date.today().strftime("%m/%d/%y")} {hour}:{minute}:00'
+	elif string_date in ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]:
+		curdate = datetime.date.today()
+
+		while curdate.strftime('%A') != string_date:
+			curdate = curdate + datetime.timedelta(day=1)
+		
+		datetime_str = f'{curdate.strftime("%m/%d/%y")} {hour}:{minute}:00'
 	else:
 		datetime_str = f'{string_date} {hour}:{minute}:00'
 	datetime_object = datetime.datetime.strptime(datetime_str, '%m/%d/%y %H:%M:%S')

--- a/auto-zoom.py
+++ b/auto-zoom.py
@@ -25,7 +25,7 @@ def convert_time(string_date, string_time):
 		curdate = datetime.date.today()
 
 		while curdate.strftime('%A') != string_date:
-			curdate = curdate + datetime.timedelta(day=1)
+			curdate = curdate + datetime.timedelta(days=1)
 		
 		datetime_str = f'{curdate.strftime("%m/%d/%y")} {hour}:{minute}:00'
 	else:

--- a/auto-zoom.py
+++ b/auto-zoom.py
@@ -6,7 +6,8 @@ def decode_link(link):
 	#extract meeting info from zoom url
 	password = link.split('pwd=')[1]
 	conference_code = link.split('/j/')[1].split('?pwd=')[0]
-	return password, conference_code
+	zoom_domain_name = link.split("//")[1].split("/j")[0]
+	return zoom_domain_name, password, conference_code
 
 def convert_time(string_date, string_time):
 	#converting HH:MM string to a datetime object
@@ -30,18 +31,22 @@ class Meeting():
 	def __init__(self, link, date, start_time, end_time):
 		self.start_time = convert_time(date, start_time)
 		self.end_time = convert_time(date, end_time)
-		self.password, self.conference_code = decode_link(link)
+		self.zoom_domain_name, self.password, self.conference_code = decode_link(link)
 
 	def join(self):
 		if platform.system() == 'Windows':
-			command = f'start zoommtg://zoom.us/join?confno={self.conference_code}?"&"pwd={self.password}'
+			command = f'start zoommtg://{self.zoom_domain_name}/join?confno={self.conference_code}?"&"pwd={self.password}'
+		elif platform.system() == 'Linux':
+			command = f'xdg-open "zoommtg://{self.zoom_domain_name}/join?confno={self.conference_code}?&pwd={self.password}"'
 		else: 
-			command = f'open "zoommtg://zoom.us/join?confno={self.conference_code}?&pwd={self.password}"'
+			command = f'open "zoommtg://{self.zoom_domain_name}/join?confno={self.conference_code}?&pwd={self.password}"'
 		os.system(command)
 
 	def quit(self):
 		if platform.system() == 'Windows':
 			os.system('taskkill /f /im Zoom.exe')
+		elif platform.system() == 'Linux':
+			os.system('killall zoom')
 		else: 
 			os.system('killall zoom.us')
 

--- a/schedule.csv
+++ b/schedule.csv
@@ -1,2 +1,3 @@
 ﻿zoom-links,"date (in mm/dd/y format, leave it blank for today)","meeting start time (in military xx:xx format, the earliest on top and in order pls)","meeting end time (in military xx:xx format, the earliest on top and in order pls)"
 https://zoom.us/j/<conference_code>?pwd=<password>,,15:45,16:30
+https://college1.zoom.us/j/<conference_code>?pwd=<password>,,16:40,17:30


### PR DESCRIPTION
Added proper Linux support by adding an if clause that checks if the platform is Linux and using correct commands:
- launching zoom links with `xdg-open` instead of `open`
- killing the zoom process by using `killall zoom` instead of `killall zoom.us`

Added support of abnormal zoom domains such as `college1.zoom.us` and `foobar.zoom.us` by making an addition to the `decode_link` function and `Meeting` class.

Added example of abnormal zoom domains in `schedule.csv` example file.

Thanks for the useful script, hopefully with Linux support more people will find a use for it without having to go into the nuts and bolts of the program.